### PR TITLE
Removing Gareth from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @shaunmulligan @xginn8 @garethtdavies
+*       @shaunmulligan @xginn8


### PR DESCRIPTION
Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>