### PR TITLE
patch: Replace balenaFin link

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ It is assumed that the reader has access to the following:
 	Either:
   * `git clone https://github.com/balena-io/balena-cli-masterclass.git`
   * Download ZIP file (from 'Clone or download'->'Download ZIP') and then unzip it to a suitable directory
-* A balena supported device, such as a [balenaFin 1.1](https://store.balena.io/collections/developer-kit/products/balenafin-developer-kit-v1-1-cm3-l),
+* A balena supported device, such as a [balenaFin 1.1](https://fin-docs.balena.io/1.1.x/getting-started/),
 	[Raspberry Pi 3](https://www.raspberrypi.org/products/raspberry-pi-3-model-b/)
 	or [Intel NUC](https://www.intel.co.uk/content/www/uk/en/products/boards-kits/nuc.html). If you don't have a device, you can emulate an Intel NUC by
 	installing VirtualBox and following [this guide](https://www.balena.io/blog/no-hardware-use-virtualbox/)


### PR DESCRIPTION
Replace balenaFin link to balenaFin docs since balenaFin has been discontinued.

Signed-off-by: Vipul Gupta (@vipulgupta2048) <vipulgupta2048@gmail.com>
