### PR TITLE
Update Dockerfile.template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%-node:8
+FROM balenalib/%%BALENA_MACHINE_NAME%%-node:latest
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
node:8 was removed so we switch this to the `:latest` tag